### PR TITLE
ブランチを作る前にmergeする処理を追加しました

### DIFF
--- a/src/Git/Daily/Command/Release.php
+++ b/src/Git/Daily/Command/Release.php
@@ -111,6 +111,17 @@ class Git_Daily_Command_Release
             throw new Git_Daily_Exception('abort');
         }
 
+        // pull current branch
+        if (isset($this->config['remote'])) {
+            self::info("pull $current_branch branch from remote");
+            list($res, $retval) = self::cmd(Git_Daily::$git, array('pull', 'origin', $current_branch));
+            if ($retval != 0) {
+                self::warn('pull failed');
+                self::outLn($res);
+                throw new Git_Daily_Exception('abort');
+            }
+        }
+
         // create release branch
         self::info("create release branch: $new_release_branch");
         $res = self::cmd(Git_Daily::$git, array('branch', $new_release_branch));

--- a/src/Git/Daily/Command/Release.php
+++ b/src/Git/Daily/Command/Release.php
@@ -407,7 +407,7 @@ class Git_Daily_Command_Release
 
 
         // return to develop
-        self::cmd(Git_Daily::$git, array('checkout', $master_branch));
+        self::cmd(Git_Daily::$git, array('checkout', $develop_branch));
         return 'release closed';
     }
 

--- a/src/Git/Daily/Command/Release.php
+++ b/src/Git/Daily/Command/Release.php
@@ -111,12 +111,15 @@ class Git_Daily_Command_Release
             throw new Git_Daily_Exception('abort');
         }
 
-        // pull current branch
+        // merge current branch
         if (isset($this->config['remote'])) {
-            self::info("pull $current_branch branch from remote");
-            list($res, $retval) = self::cmd(Git_Daily::$git, array('pull', 'origin', $current_branch));
+            //
+            // Fetch --all is already done. Just git merge.
+            //
+            self::info("merge $current_branch branch from remote");
+            list($res, $retval) = self::cmd(Git_Daily::$git, array('merge', 'origin/' . $current_branch));
             if ($retval != 0) {
-                self::warn('pull failed');
+                self::warn('merge failed');
                 self::outLn($res);
                 throw new Git_Daily_Exception('abort');
             }


### PR DESCRIPTION
git-dailyでrelease openする際に、developブランチの内容が古いままbranchを切ってしまう問題が見つかりました。fetch --allしたあとにmerge origin/developで実際にマージする必要があるようです。

すみませんがご確認よろしくおねがいします。
